### PR TITLE
v0.3 - Lint, JSON output, parallel execution

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { testCommand } from './commands/test.command.js';
 import { testStorageCommand } from './commands/test-storage.command.js';
 import { exportPgtapCommand } from './commands/export-pgtap.command.js';
 import { auditCommand } from './commands/audit.command.js';
+import { lintCommand } from './commands/lint.command.js';
 import { coverageCommand } from './commands/coverage.command.js';
 import { snapshotCommand } from './commands/snapshot.command.js';
 import { diffCommand } from './commands/diff.command.js';
@@ -53,6 +54,7 @@ program
   });
 
 program.addCommand(auditCommand);
+program.addCommand(lintCommand);
 program.addCommand(coverageCommand);
 program.addCommand(snapshotCommand);
 program.addCommand(diffCommand);

--- a/src/commands/coverage.command.ts
+++ b/src/commands/coverage.command.ts
@@ -111,7 +111,7 @@ function collectWarnings(report: CoverageReport): string[] {
 
 function printWarnings(warnings: string[]) {
   if (warnings.length === 0) {
-    console.log(chalk.green('✓ No security warnings detected'));
+    console.log(chalk.green('No security warnings detected'));
     console.log('');
     return;
   }

--- a/src/commands/lint.command.ts
+++ b/src/commands/lint.command.ts
@@ -10,7 +10,7 @@ export const lintCommand = new Command('lint')
   .option('--json', 'Output results as JSON')
   .action(async (options) => {
     await withDatabaseConnection(options, async ({ pool, logger }) => {
-      logger.start('Linting RLS policies...');
+      if (!options.json) logger.start('Linting RLS policies...');
 
       const client = await pool.connect();
       let results: LintResults;
@@ -21,7 +21,7 @@ export const lintCommand = new Command('lint')
         client.release();
       }
 
-      logger.succeed('Policy linting complete.');
+      if (!options.json) logger.succeed('Policy linting complete.');
 
       if (options.json) {
         console.log(JSON.stringify(results, null, 2));

--- a/src/commands/lint.command.ts
+++ b/src/commands/lint.command.ts
@@ -1,0 +1,93 @@
+import { Command } from 'commander';
+import { withDatabaseConnection } from '../shared/command-utils.js';
+import { lintPolicies, type LintResults, type LintIssue } from '../core/lint.js';
+
+export const lintCommand = new Command('lint')
+  .description('Static analysis of RLS policy expressions for security issues')
+  .option('-u, --url <url>', 'Database connection URL')
+  .option('--all-schemas', 'Include system tables (auth, storage, etc.)')
+  .option('--verbose', 'Enable verbose logging')
+  .option('--json', 'Output results as JSON')
+  .action(async (options) => {
+    await withDatabaseConnection(options, async ({ pool, logger }) => {
+      logger.start('Linting RLS policies...');
+
+      const client = await pool.connect();
+      let results: LintResults;
+
+      try {
+        results = await lintPolicies(client, options.allSchemas || false);
+      } finally {
+        client.release();
+      }
+
+      logger.succeed('Policy linting complete.');
+
+      if (options.json) {
+        console.log(JSON.stringify(results, null, 2));
+      } else {
+        displayLintResults(results);
+      }
+
+      const hasCriticalOrHigh = results.criticalCount > 0 || results.highCount > 0;
+      if (hasCriticalOrHigh) {
+        process.exit(1);
+      }
+    });
+  });
+
+function displayLintResults(results: LintResults): void {
+  console.log('\nPolicy Lint Results:');
+
+  if (results.totalIssues === 0) {
+    console.log('  No issues found\n');
+    return;
+  }
+
+  console.log(`  Found ${results.totalIssues} issue(s) ` +
+    `(${results.criticalCount} critical, ${results.highCount} high, ${results.mediumCount} medium)\n`);
+
+  const groupedIssues = groupIssuesBySeverity(results.issues);
+
+  for (const severity of ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const) {
+    const issues = groupedIssues[severity];
+    if (issues.length === 0) continue;
+
+    displayIssuesForSeverity(severity, issues);
+  }
+}
+
+function groupIssuesBySeverity(issues: LintIssue[]): Record<string, LintIssue[]> {
+  return issues.reduce((acc, issue) => {
+    if (!acc[issue.severity]) {
+      acc[issue.severity] = [];
+    }
+    acc[issue.severity].push(issue);
+    return acc;
+  }, {} as Record<string, LintIssue[]>);
+}
+
+function displayIssuesForSeverity(severity: string, issues: LintIssue[]): void {
+  const title = formatSeverityTitle(severity);
+  console.log(`${severity}: ${title}`);
+
+  for (const issue of issues) {
+    console.log(`  Policy: ${issue.policy}`);
+    console.log(`  Issue: ${issue.issue}`);
+    if (issue.expression) {
+      console.log(`  Expression: ${issue.expression}`);
+    }
+    console.log(`  Fix: ${issue.fix}`);
+    console.log('');
+  }
+}
+
+function formatSeverityTitle(severity: string): string {
+  const titles: Record<string, string> = {
+    CRITICAL: 'Always-true policies or critical security flaws',
+    HIGH: 'Missing authentication checks',
+    MEDIUM: 'Policy configuration issues',
+    LOW: 'Minor issues'
+  };
+  return titles[severity] || '';
+}

--- a/src/commands/test.command.ts
+++ b/src/commands/test.command.ts
@@ -14,6 +14,7 @@ import type {
   TableTestConfiguration
 } from '../shared/types.js';
 import { SUPPORTED_DATABASE_OPERATIONS, CONSOLE_MESSAGES } from '../shared/constants.js';
+import { type Logger } from '../shared/logger.js';
 import { updateTestCounters, loadPolicyConfig } from '../shared/test-utils.js';
 import { withDatabaseConnection } from '../shared/command-utils.js';
 import { executePromisesInParallel } from '../shared/parallel.js';

--- a/src/core/lint.ts
+++ b/src/core/lint.ts
@@ -1,0 +1,184 @@
+import type { PoolClient } from 'pg';
+
+export type LintSeverity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface PolicyLintData {
+  schema: string;
+  table: string;
+  policy_name: string;
+  command: string;
+  using_expression: string | null;
+  with_check_expression: string | null;
+  roles: string[];
+}
+
+export interface LintIssue {
+  severity: LintSeverity;
+  check_id: string;
+  policy: string;
+  issue: string;
+  expression?: string;
+  fix: string;
+}
+
+export interface LintResults {
+  issues: LintIssue[];
+  totalIssues: number;
+  criticalCount: number;
+  highCount: number;
+  mediumCount: number;
+}
+
+const LINT_CHECKS = [
+  {
+    id: 'ALWAYS_TRUE_USING',
+    severity: 'CRITICAL' as LintSeverity,
+    check: (policy: PolicyLintData): LintIssue | null => {
+      const expr = policy.using_expression?.trim();
+      if (expr === 'true' || expr === '(true)') {
+        return {
+          severity: 'CRITICAL',
+          check_id: 'ALWAYS_TRUE_USING',
+          policy: `${policy.schema}.${policy.table}.${policy.policy_name}`,
+          issue: "USING expression is literally 'true' - allows unrestricted access",
+          expression: policy.using_expression || undefined,
+          fix: 'Add proper row filtering, e.g., USING (auth.uid() = user_id)'
+        };
+      }
+      return null;
+    }
+  },
+  {
+    id: 'ALWAYS_TRUE_WITH_CHECK',
+    severity: 'CRITICAL' as LintSeverity,
+    check: (policy: PolicyLintData): LintIssue | null => {
+      const expr = policy.with_check_expression?.trim();
+      if (expr === 'true' || expr === '(true)') {
+        return {
+          severity: 'CRITICAL',
+          check_id: 'ALWAYS_TRUE_WITH_CHECK',
+          policy: `${policy.schema}.${policy.table}.${policy.policy_name}`,
+          issue: "WITH CHECK expression is literally 'true' - allows unrestricted modifications",
+          expression: policy.with_check_expression || undefined,
+          fix: 'Add proper row filtering, e.g., WITH CHECK (auth.uid() = user_id)'
+        };
+      }
+      return null;
+    }
+  },
+  {
+    id: 'NO_AUTH_UID_CHECK',
+    severity: 'HIGH' as LintSeverity,
+    check: (policy: PolicyLintData): LintIssue | null => {
+      if (policy.command !== 'SELECT') return null;
+      const expr = policy.using_expression || '';
+      if (!expr.includes('auth.uid()') && expr !== 'true' && expr !== '(true)') {
+        return {
+          severity: 'HIGH',
+          check_id: 'NO_AUTH_UID_CHECK',
+          policy: `${policy.schema}.${policy.table}.${policy.policy_name}`,
+          issue: "SELECT policy doesn't verify user identity",
+          expression: policy.using_expression || undefined,
+          fix: 'Consider adding auth.uid() check if this table contains user data'
+        };
+      }
+      return null;
+    }
+  },
+  {
+    id: 'PERMISSIVE_FOR_ALL',
+    severity: 'MEDIUM' as LintSeverity,
+    check: (policy: PolicyLintData): LintIssue | null => {
+      if (policy.roles.includes('{0}') || policy.roles.includes('0')) {
+        return {
+          severity: 'MEDIUM',
+          check_id: 'PERMISSIVE_FOR_ALL',
+          policy: `${policy.schema}.${policy.table}.${policy.policy_name}`,
+          issue: 'Policy applies to all roles (polroles = {0})',
+          fix: 'Consider restricting to specific roles like anon, authenticated'
+        };
+      }
+      return null;
+    }
+  },
+  {
+    id: 'MISSING_WITH_CHECK',
+    severity: 'MEDIUM' as LintSeverity,
+    check: (policy: PolicyLintData): LintIssue | null => {
+      const hasUsing = policy.using_expression != null;
+      const hasWithCheck = policy.with_check_expression != null;
+      const isInsertOrUpdate = policy.command === 'INSERT' || policy.command === 'UPDATE';
+
+      if (isInsertOrUpdate && hasUsing && !hasWithCheck) {
+        return {
+          severity: 'MEDIUM',
+          check_id: 'MISSING_WITH_CHECK',
+          policy: `${policy.schema}.${policy.table}.${policy.policy_name}`,
+          issue: 'INSERT/UPDATE policy has USING but no WITH CHECK',
+          fix: 'Add WITH CHECK expression to validate modifications'
+        };
+      }
+      return null;
+    }
+  }
+] as const;
+
+export async function lintPolicies(
+  client: PoolClient,
+  includeSystemSchemas: boolean
+): Promise<LintResults> {
+  const policies = await fetchPoliciesForLinting(client, includeSystemSchemas);
+  const issues: LintIssue[] = [];
+
+  for (const policy of policies) {
+    for (const lintCheck of LINT_CHECKS) {
+      const issue = lintCheck.check(policy);
+      if (issue) {
+        issues.push(issue);
+      }
+    }
+  }
+
+  return categorizeIssues(issues);
+}
+
+async function fetchPoliciesForLinting(
+  client: PoolClient,
+  includeSystemSchemas: boolean
+): Promise<PolicyLintData[]> {
+  const schemaCondition = includeSystemSchemas
+    ? "nsp.nspname NOT IN ('pg_catalog', 'information_schema')"
+    : "nsp.nspname = 'public'";
+
+  const { rows } = await client.query<PolicyLintData>(`
+    SELECT
+      nsp.nspname as schema,
+      cls.relname as table,
+      pol.polname as policy_name,
+      pol.polcmd as command,
+      pg_get_expr(pol.polqual, pol.polrelid) as using_expression,
+      pg_get_expr(pol.polwithcheck, pol.polrelid) as with_check_expression,
+      pol.polroles::regrole[] as roles
+    FROM pg_policy pol
+    JOIN pg_class cls ON pol.polrelid = cls.oid
+    JOIN pg_namespace nsp ON cls.relnamespace = nsp.oid
+    WHERE ${schemaCondition}
+    ORDER BY nsp.nspname, cls.relname, pol.polname;
+  `);
+
+  return rows;
+}
+
+function categorizeIssues(issues: LintIssue[]): LintResults {
+  const criticalCount = issues.filter(i => i.severity === 'CRITICAL').length;
+  const highCount = issues.filter(i => i.severity === 'HIGH').length;
+  const mediumCount = issues.filter(i => i.severity === 'MEDIUM').length;
+
+  return {
+    issues,
+    totalIssues: issues.length,
+    criticalCount,
+    highCount,
+    mediumCount
+  };
+}

--- a/src/core/lint.ts
+++ b/src/core/lint.ts
@@ -158,7 +158,11 @@ async function fetchPoliciesForLinting(
       pol.polcmd as command,
       pg_get_expr(pol.polqual, pol.polrelid) as using_expression,
       pg_get_expr(pol.polwithcheck, pol.polrelid) as with_check_expression,
-      pol.polroles::regrole[] as roles
+      ARRAY(
+        SELECT CASE WHEN r.oid = 0 THEN 'PUBLIC' ELSE r.rolname END
+        FROM unnest(pol.polroles) AS pr(oid)
+        LEFT JOIN pg_roles r ON r.oid = pr.oid
+      ) as roles
     FROM pg_policy pol
     JOIN pg_class cls ON pol.polrelid = cls.oid
     JOIN pg_namespace nsp ON cls.relnamespace = nsp.oid

--- a/src/core/lint.ts
+++ b/src/core/lint.ts
@@ -155,7 +155,13 @@ async function fetchPoliciesForLinting(
       nsp.nspname as schema,
       cls.relname as table,
       pol.polname as policy_name,
-      pol.polcmd as command,
+      CASE pol.polcmd
+        WHEN 'r' THEN 'SELECT'
+        WHEN 'a' THEN 'INSERT'
+        WHEN 'w' THEN 'UPDATE'
+        WHEN 'd' THEN 'DELETE'
+        WHEN '*' THEN 'ALL'
+      END as command,
       pg_get_expr(pol.polqual, pol.polrelid) as using_expression,
       pg_get_expr(pol.polwithcheck, pol.polrelid) as with_check_expression,
       ARRAY(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -87,6 +87,12 @@ export const COLUMN_TYPE_TEST_VALUES = {
   INTEGER: '1',
   NUMERIC: '1',
   BOOLEAN: 'true',
+  TIMESTAMP: 'now()',
+  TIMESTAMPTZ: 'now()',
+  DATE: 'CURRENT_DATE',
+  INET: "'127.0.0.1'",
+  JSONB: "'{}'::jsonb",
+  JSON: "'{}'::json",
   DEFAULT: 'DEFAULT',
 } as const;
 
@@ -101,4 +107,18 @@ export const POSTGRESQL_SYSTEM_ROLES = {
 export const DEFAULT_TEST_SCENARIO_NAMES = {
   ANONYMOUS_USER: 'anonymous_user',
   AUTHENTICATED_USER: 'authenticated_user',
-} as const; 
+} as const;
+
+// Sensitive column patterns for security audit
+export const SENSITIVE_COLUMN_PATTERNS = [
+  /password/i,
+  /secret/i,
+  /token/i,
+  /ssn/i,
+  /social_security/i,
+  /credit_card/i,
+  /api_key/i,
+  /private_key/i,
+  /salary/i,
+  /bank_account/i,
+] as const; 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -62,10 +62,18 @@ export function formatTestResult(result: {
   operation: string;
   actual: string;
   expected: string;
+  error_message?: string;
 }): string {
+  const operation = result.operation.padEnd(6, ' ');
+  
+  // Handle SKIPPED separately
+  if (result.actual === 'SKIPPED') {
+    const reason = result.error_message || 'Could not seed test data';
+    return `    ${chalk.yellow('SKIP')} ${operation}: ${chalk.yellow(reason)}`;
+  }
+  
   const status = result.passed ? 'PASS' : 'FAIL';
   const statusColor = result.passed ? chalk.green(status) : chalk.red(status);
-  const operation = result.operation.padEnd(6, ' ');
   const details = result.passed
     ? chalk.green(`${result.actual} (expected ${result.expected})`)
     : chalk.red(`${result.actual} (expected ${result.expected}) - MISMATCH!`);
@@ -83,6 +91,7 @@ export function formatSummary(results: {
   passed_tests: number;
   failed_tests: number;
   error_tests: number;
+  skipped_tests?: number;
   execution_time_ms: number;
 }): string {
   const summary = [
@@ -91,6 +100,10 @@ export function formatSummary(results: {
     chalk.green(`  Passed: ${results.passed_tests}`),
     chalk.red(`  Failed: ${results.failed_tests}`),
   ];
+
+  if (results.skipped_tests && results.skipped_tests > 0) {
+    summary.push(chalk.yellow(`  Skipped: ${results.skipped_tests} (tables need test data - run 'supashield audit' for details)`));
+  }
 
   if (results.error_tests > 0) {
     summary.push(chalk.red.bold(`  Errors: ${results.error_tests}`));

--- a/src/shared/output.ts
+++ b/src/shared/output.ts
@@ -1,0 +1,127 @@
+import type { TestResults, TestResultDetail } from './types.js';
+import type { Logger } from './logger.js';
+
+export interface JsonOutput {
+  verdict: 'SECURE' | 'INSECURE';
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    errors: number;
+    execution_time_ms: number;
+  };
+  issues: Array<{
+    severity: 'CRITICAL' | 'HIGH';
+    table: string;
+    scenario: string;
+    operation: string;
+    expected: string;
+    actual: string;
+    diagnosis: string;
+    suggested_fix: string | null;
+  }>;
+  skipped: Array<{
+    table: string;
+    operation: string;
+    reason: string;
+  }>;
+}
+
+export function formatTestResultsAsJson(results: TestResults): JsonOutput {
+  const failures = results.detailed_results.filter(r => !r.passed && r.actual !== 'SKIPPED');
+  const skipped = results.detailed_results.filter(r => r.actual === 'SKIPPED');
+  
+  return {
+    verdict: results.failed_tests === 0 && results.error_tests === 0 ? 'SECURE' : 'INSECURE',
+    summary: {
+      total: results.total_tests,
+      passed: results.passed_tests,
+      failed: results.failed_tests,
+      skipped: results.skipped_tests,
+      errors: results.error_tests,
+      execution_time_ms: Math.round(results.execution_time_ms),
+    },
+    issues: failures.map(f => ({
+      severity: f.actual === 'ALLOW' && f.expected === 'DENY' ? 'CRITICAL' as const : 'HIGH' as const,
+      table: f.table_key,
+      scenario: f.scenario_name,
+      operation: f.operation,
+      expected: f.expected,
+      actual: f.actual,
+      diagnosis: getDiagnosis(f),
+      suggested_fix: getSuggestedFix(f),
+    })),
+    skipped: skipped.map(s => ({
+      table: s.table_key,
+      operation: s.operation,
+      reason: s.error_message || 'Unknown',
+    })),
+  };
+}
+
+export function printTestResultsForHumans(results: TestResults, logger: Logger, quiet: boolean): void {
+  const failures = results.detailed_results.filter(r => !r.passed && r.actual !== 'SKIPPED');
+  const critical = failures.filter(f => f.actual === 'ALLOW' && f.expected === 'DENY');
+  
+  console.log('');
+  if (results.failed_tests === 0 && results.error_tests === 0) {
+    console.log('SECURE - All policy tests passed');
+  } else if (critical.length > 0) {
+    console.log(`INSECURE - ${critical.length} critical issue(s) found`);
+  } else {
+    console.log(`WARNING - ${results.failed_tests} policy mismatch(es) detected`);
+  }
+  console.log('');
+  
+  if (critical.length > 0) {
+    console.log('CRITICAL ISSUES (potential data leaks):');
+    for (const issue of critical) {
+      console.log(`  ${issue.table_key}: ${issue.scenario_name} can ${issue.operation}`);
+      console.log(`    ${getDiagnosis(issue)}`);
+      const fix = getSuggestedFix(issue);
+      if (fix) console.log(`    FIX: ${fix}`);
+      console.log('');
+    }
+  }
+  
+  const otherFailures = failures.filter(f => !(f.actual === 'ALLOW' && f.expected === 'DENY'));
+  if (otherFailures.length > 0 && !quiet) {
+    console.log('OTHER MISMATCHES:');
+    for (const issue of otherFailures) {
+      console.log(`  ${issue.table_key}: ${issue.scenario_name}.${issue.operation} = ${issue.actual} (expected ${issue.expected})`);
+    }
+    console.log('');
+  }
+  
+  if (results.skipped_tests > 0 && !quiet) {
+    console.log(`SKIPPED: ${results.skipped_tests} tests (FK constraints or missing test data)`);
+    console.log('');
+  }
+  
+  console.log(`Tests: ${results.passed_tests} passed, ${results.failed_tests} failed, ${results.skipped_tests} skipped (${Math.round(results.execution_time_ms)}ms)`);
+}
+
+function getDiagnosis(result: TestResultDetail): string {
+  if (result.actual === 'ALLOW' && result.expected === 'DENY') {
+    if (result.scenario_name.includes('anonymous')) {
+      return 'Anonymous users can access this data - missing RLS policy';
+    }
+    return 'Access granted when it should be denied';
+  }
+  if (result.actual === 'DENY' && result.expected === 'ALLOW') {
+    return 'Access denied - RLS policy may be too restrictive';
+  }
+  return 'Unexpected behavior';
+}
+
+function getSuggestedFix(result: TestResultDetail): string | null {
+  if (result.actual === 'ALLOW' && result.expected === 'DENY') {
+    const [schema, table] = result.table_key.split('.');
+    if (result.scenario_name.includes('anonymous')) {
+      return `CREATE POLICY "${table}_deny_anon_${result.operation.toLowerCase()}" ON ${result.table_key} FOR ${result.operation} TO anon USING (false);`;
+    }
+    return `CREATE POLICY "${table}_${result.operation.toLowerCase()}" ON ${result.table_key} FOR ${result.operation} USING (auth.uid() = user_id);`;
+  }
+  return null;
+}

--- a/src/shared/test-utils.ts
+++ b/src/shared/test-utils.ts
@@ -10,6 +10,8 @@ export function updateTestCounters(
   results.total_tests++;
   if (result.passed) {
     results.passed_tests++;
+  } else if (result.actual === 'SKIPPED') {
+    results.skipped_tests++;
   } else if (result.actual === 'ERROR') {
     results.error_tests++;
   } else {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -88,6 +88,7 @@ export interface TestResults {
   passed_tests: number;
   failed_tests: number;
   error_tests: number;
+  skipped_tests: number;
   execution_time_ms: number;
   detailed_results: TestResultDetail[];
 }
@@ -105,7 +106,7 @@ export interface TestResultDetail {
 
 // Enums for better type safety and elimination of magic strings
 export type DatabaseOperation = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE';
-export type ProbeResult = 'ALLOW' | 'DENY' | 'ERROR';
+export type ProbeResult = 'ALLOW' | 'DENY' | 'ERROR' | 'SKIPPED';
 export type UserRole = 'anonymous' | 'authenticated' | string;
 
 export interface ColumnIntrospectionResult {

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1,0 +1,295 @@
+import { describe, test, expect } from 'vitest';
+import type { PolicyLintData } from '../src/core/lint.js';
+
+describe('Lint - Policy Expression Analysis', () => {
+  describe('ALWAYS_TRUE_USING Detection', () => {
+    test('detects literal true in USING clause', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'bad_policy',
+        command: 'SELECT',
+        using_expression: 'true',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const isAlwaysTrue = policy.using_expression?.trim() === 'true';
+      expect(isAlwaysTrue).toBe(true);
+    });
+
+    test('detects parenthesized true in USING clause', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'bad_policy',
+        command: 'SELECT',
+        using_expression: '(true)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const isAlwaysTrue = policy.using_expression?.trim() === '(true)';
+      expect(isAlwaysTrue).toBe(true);
+    });
+
+    test('does not flag proper USING expression', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'good_policy',
+        command: 'SELECT',
+        using_expression: '(auth.uid() = user_id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const isAlwaysTrue = policy.using_expression?.trim() === 'true' ||
+                          policy.using_expression?.trim() === '(true)';
+      expect(isAlwaysTrue).toBe(false);
+    });
+  });
+
+  describe('ALWAYS_TRUE_WITH_CHECK Detection', () => {
+    test('detects literal true in WITH CHECK clause', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'bad_policy',
+        command: 'INSERT',
+        using_expression: null,
+        with_check_expression: 'true',
+        roles: ['authenticated']
+      };
+
+      const isAlwaysTrue = policy.with_check_expression?.trim() === 'true';
+      expect(isAlwaysTrue).toBe(true);
+    });
+
+    test('detects parenthesized true in WITH CHECK clause', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'bad_policy',
+        command: 'UPDATE',
+        using_expression: null,
+        with_check_expression: '(true)',
+        roles: ['authenticated']
+      };
+
+      const isAlwaysTrue = policy.with_check_expression?.trim() === '(true)';
+      expect(isAlwaysTrue).toBe(true);
+    });
+  });
+
+  describe('NO_AUTH_UID_CHECK Detection', () => {
+    test('flags SELECT policy without auth.uid()', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'select_published',
+        command: 'SELECT',
+        using_expression: '(status = \'published\')',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const hasAuthUid = policy.using_expression?.includes('auth.uid()');
+      const shouldFlag = policy.command === 'SELECT' && !hasAuthUid;
+      expect(shouldFlag).toBe(true);
+    });
+
+    test('does not flag SELECT policy with auth.uid()', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'select_own',
+        command: 'SELECT',
+        using_expression: '(auth.uid() = user_id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const hasAuthUid = policy.using_expression?.includes('auth.uid()');
+      expect(hasAuthUid).toBe(true);
+    });
+
+    test('does not flag non-SELECT policies', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'insert_posts',
+        command: 'INSERT',
+        using_expression: null,
+        with_check_expression: '(status = \'draft\')',
+        roles: ['authenticated']
+      };
+
+      const shouldFlag = policy.command === 'SELECT';
+      expect(shouldFlag).toBe(false);
+    });
+  });
+
+  describe('PERMISSIVE_FOR_ALL Detection', () => {
+    test('detects policy for all roles', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'allow_all',
+        command: 'SELECT',
+        using_expression: '(true)',
+        with_check_expression: null,
+        roles: ['{0}']
+      };
+
+      const appliesToAll = policy.roles.includes('{0}') || policy.roles.includes('0');
+      expect(appliesToAll).toBe(true);
+    });
+
+    test('does not flag role-specific policy', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'users',
+        policy_name: 'select_own',
+        command: 'SELECT',
+        using_expression: '(auth.uid() = id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const appliesToAll = policy.roles.includes('{0}') || policy.roles.includes('0');
+      expect(appliesToAll).toBe(false);
+    });
+  });
+
+  describe('MISSING_WITH_CHECK Detection', () => {
+    test('flags INSERT with USING but no WITH CHECK', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'insert_posts',
+        command: 'INSERT',
+        using_expression: '(auth.uid() = user_id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const hasUsing = policy.using_expression != null;
+      const hasWithCheck = policy.with_check_expression != null;
+      const isInsertOrUpdate = policy.command === 'INSERT' || policy.command === 'UPDATE';
+      const shouldFlag = isInsertOrUpdate && hasUsing && !hasWithCheck;
+
+      expect(shouldFlag).toBe(true);
+    });
+
+    test('flags UPDATE with USING but no WITH CHECK', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'update_posts',
+        command: 'UPDATE',
+        using_expression: '(auth.uid() = user_id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const hasUsing = policy.using_expression != null;
+      const hasWithCheck = policy.with_check_expression != null;
+      const isInsertOrUpdate = policy.command === 'INSERT' || policy.command === 'UPDATE';
+      const shouldFlag = isInsertOrUpdate && hasUsing && !hasWithCheck;
+
+      expect(shouldFlag).toBe(true);
+    });
+
+    test('does not flag INSERT with both USING and WITH CHECK', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'insert_posts',
+        command: 'INSERT',
+        using_expression: '(true)',
+        with_check_expression: '(auth.uid() = user_id)',
+        roles: ['authenticated']
+      };
+
+      const hasUsing = policy.using_expression != null;
+      const hasWithCheck = policy.with_check_expression != null;
+      const isInsertOrUpdate = policy.command === 'INSERT' || policy.command === 'UPDATE';
+      const shouldFlag = isInsertOrUpdate && hasUsing && !hasWithCheck;
+
+      expect(shouldFlag).toBe(false);
+    });
+
+    test('does not flag SELECT policy', () => {
+      const policy: PolicyLintData = {
+        schema: 'public',
+        table: 'posts',
+        policy_name: 'select_posts',
+        command: 'SELECT',
+        using_expression: '(auth.uid() = user_id)',
+        with_check_expression: null,
+        roles: ['authenticated']
+      };
+
+      const hasUsing = policy.using_expression != null;
+      const hasWithCheck = policy.with_check_expression != null;
+      const isInsertOrUpdate = policy.command === 'INSERT' || policy.command === 'UPDATE';
+      const shouldFlag = isInsertOrUpdate && hasUsing && !hasWithCheck;
+
+      expect(shouldFlag).toBe(false);
+    });
+  });
+
+  describe('Schema Filtering Logic', () => {
+    test('generates public schema condition when not including system schemas', () => {
+      const includeSystemSchemas = false;
+      const schemaCondition = includeSystemSchemas
+        ? "nsp.nspname NOT IN ('pg_catalog', 'information_schema')"
+        : "nsp.nspname = 'public'";
+
+      expect(schemaCondition).toBe("nsp.nspname = 'public'");
+    });
+
+    test('generates exclusion condition when including system schemas', () => {
+      const includeSystemSchemas = true;
+      const schemaCondition = includeSystemSchemas
+        ? "nsp.nspname NOT IN ('pg_catalog', 'information_schema')"
+        : "nsp.nspname = 'public'";
+
+      expect(schemaCondition).toContain('NOT IN');
+      expect(schemaCondition).toContain('pg_catalog');
+      expect(schemaCondition).toContain('information_schema');
+    });
+  });
+
+  describe('Issue Categorization', () => {
+    test('counts issues by severity correctly', () => {
+      const issues = [
+        { severity: 'CRITICAL' as const, check_id: 'TEST1', policy: 'p1', issue: 'i1', fix: 'f1' },
+        { severity: 'CRITICAL' as const, check_id: 'TEST2', policy: 'p2', issue: 'i2', fix: 'f2' },
+        { severity: 'HIGH' as const, check_id: 'TEST3', policy: 'p3', issue: 'i3', fix: 'f3' },
+        { severity: 'MEDIUM' as const, check_id: 'TEST4', policy: 'p4', issue: 'i4', fix: 'f4' },
+      ];
+
+      const criticalCount = issues.filter(i => i.severity === 'CRITICAL').length;
+      const highCount = issues.filter(i => i.severity === 'HIGH').length;
+      const mediumCount = issues.filter(i => i.severity === 'MEDIUM').length;
+
+      expect(criticalCount).toBe(2);
+      expect(highCount).toBe(1);
+      expect(mediumCount).toBe(1);
+      expect(issues.length).toBe(4);
+    });
+  });
+
+  describe('Policy Name Formatting', () => {
+    test('creates fully qualified policy name', () => {
+      const schema = 'public';
+      const table = 'users';
+      const policyName = 'select_own';
+      const fullName = `${schema}.${table}.${policyName}`;
+
+      expect(fullName).toBe('public.users.select_own');
+    });
+  });
+});


### PR DESCRIPTION
- Add supashield lint for static analysis of RLS policy expressions
- Add --json output mode for AI/CI integration
- Add --quiet flag to show only failures
- Add parallel test execution (default: 4 concurrent)
- Add sensitive column grant detection to audit
- Handle FK constraint failures gracefully (SKIPPED instead of ERROR)
- Fix suggestions in output (copy-paste SQL)

New Commands
supashield lint                  # static analysis of policy expressions
supashield test --json           # machine-readable output
supashield test --quiet          # failures only
supashield test --parallel 8     # control concurrency
supashield lint                  # static analysis of policy expressionssupashield test --json           # machine-readable outputsupashield test --quiet          # failures onlysupashield test --parallel 8     # control concurrency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added lint command for RLS policy static analysis; test command supports parallel execution, --json output, and --quiet mode
  * Audit: detects sensitive column exposure and surfaces high-priority issues

* **Enhancements**
  * JSON test output schema and improved human-friendly reports
  * Expanded probe/test data types, more robust seeding, and skipped-test tracking

* **Documentation**
  * Updated Quick Start, AI-assisted development, CI/CD guidance, and example output/reporting

* **Tests**
  * Added/expanded unit tests for linting, auditing, parallel execution, and probes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->